### PR TITLE
Update get-started.md

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -67,25 +67,12 @@ react-native link react-native-square-in-app-payments
 To use the In-App Payments plugin on iOS devices, install **In-App Payments SDK for iOS** 
 to make it an available resource for the React Native plugin. 
 
-1. Open your iOS project `myRNInAppPaymentsSample.xcodeproj` with **Xcode** and install **In-App Payments SDK** by following  
-[Install In-App Payments SDK - Swift(iOS) Option 3: Manual Installation]. You **MUST**
-put the **SquareInAppPaymentsSDK.framework** in folder `<YOUR_PROJECT_DIRECTORY>/ios`, otherwise
-the project won't compile.
-    > Check the supported SDK version in the top of [root README].
+1. Open your iOS project `myRNInAppPaymentsSample.xcodeproj` with **Xcode** and install **In-App Payments SDK** by adding the following to your Podfile:
+  ```
+  pod "SquareInAppPaymentsSDK"
+  ```
+1. Run `pod install`
 1. Set the `iOS Deployment Target` to 11.0 or above
-1. Add an In-App Payments SDK build phase:
-    1. Open the **Xcode** project for your application.
-    1. In the **Build Phases** tab for your application target, click the **+**
-        button at the top of the pane.
-    1. Select **New Run Script Phase**.
-    1. Paste the following into the editor panel of the new run script:
-        ```
-        FRAMEWORKS="${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}"
-        "${FRAMEWORKS}/SquareInAppPaymentsSDK.framework/setup"
-        ```
-1. Correct the resource bundle location in your project target `myRNInAppPaymentsSample`
-    1. In the `Link Binary With Libraries` build phase, remove `RNSquareInAppPayments-Resources.bundle`.
-    1. In the `Copy Bundle Resources` build phase, add `RNSquareInAppPayments-Resources.bundle` from `Libraries`->`RNSquareInAppPayments.xcodeproj`.
 
 ## Step 4: Configure your Android project
 
@@ -104,7 +91,7 @@ are just examples.
           compileSdkVersion = 28
           targetSdkVersion = 27
           supportLibVersion = "28.0.0"
-          sqipVersion = "1.1.0"
+          sqipVersion = "1.2.0"
       }
       ...
     }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/in-app-payments-react-native-plugin/blob/master/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
For iOS:
Cocoapods has removed the use of use_frameworks! and this breaks the react-native libraries. Adding the frameworks build phase, adding the .framework file to the top of the project and linking the libraries in XCode is no longer needed.


For Android:
sqipVersion = "1.1.0" doesn't work with the testing cards so I recommend a change to "1.2.0" which is the latest and works with the testing cards.

## Related issues
https://developer.squareup.com/docs/in-app-payments-sdk/installation#option-3-install-the-in-app-payments-sdk-manually contains the same "use_frameworks!" problem.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/in-app-payments-react-native-plugin/blob/master/CHANGELOG.md for an example. -->
v1.0.0 August 20, 2019
* Initial suggestions

## Test Plan

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->
http://blog.cocoapods.org/CocoaPods-1.5.0/
"With CocoaPods 1.5.0, developers are no longer restricted into specifying use_frameworks! in their Podfile in order to install pods that use Swift. Interop with Objective-C should just work."