### PR TITLE
Jessiedlcs/upgrade handle bars dep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v1.3.1 January 8, 2020
 
-* Bump Nested HandleBar dependency from 4.20 to 4.5.3.
+* Bump Nested HandleBar dependency from 4.2.0 to 4.5.3.
 
 ### v1.3.0 November 25, 2019
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.3.1 January 8, 2020
+
+* Bump Nested HandleBar dependency from 4.20 to 4.5.3.
+
 ### v1.3.0 November 25, 2019
 
 * Bump Square In-App Payments SDK dependency to `1.3.0`.

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "modulePathIgnorePatterns": [
       "react-native-in-app-payments-quickstart"
     ]
+  },
+  "resolutions": {
+    "**/**/handlebars": "4.5.3"
   }
 }

--- a/react-native-in-app-payments-quickstart/package.json
+++ b/react-native-in-app-payments-quickstart/package.json
@@ -30,5 +30,8 @@
   },
   "jest": {
     "preset": "react-native"
+  },
+  "resolutions": {
+    "**/**/handlebars": "4.5.3"
   }
 }

--- a/react-native-in-app-payments-quickstart/yarn.lock
+++ b/react-native-in-app-payments-quickstart/yarn.lock
@@ -3032,10 +3032,10 @@ hammerjs@^2.0.8:
   resolved "https://registry.yarnpkg.com/hammerjs/-/hammerjs-2.0.8.tgz#04ef77862cff2bb79d30f7692095930222bf60f1"
   integrity sha1-BO93hiz/K7edMPdpIJWTAiK/YPE=
 
-handlebars@^4.1.2:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.2.0.tgz#57ce8d2175b9bbb3d8b3cf3e4217b1aec8ddcb2e"
-  integrity sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==
+handlebars@4.5.3, handlebars@^4.1.2:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2874,10 +2874,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.1.2:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.2.0.tgz#57ce8d2175b9bbb3d8b3cf3e4217b1aec8ddcb2e"
-  integrity sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==
+handlebars@4.5.3, handlebars@^4.1.2:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
## Summary

Upgrades handlebars dependency from 4.2.0 to 4.5.3 . Handbars  is a dependency brought in from jest.



