### PR TITLE
Bump to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v1.6.0 July 19, 2021
+
+* Downgrading IAP SDK to 1.4.9 to solve compatability issue with newer versions of the IAP SDK
+
 ### v1.5.0 May 14, 2021
 
 * Added a new flow called [startBuyerVerificationFlow](docs/reference.md#startbuyerverificationflow) to support Strong Customer Authentication with a card-on-file card ID
@@ -9,7 +13,7 @@
 ### v1.4.0 July 10, 2020
 
 * Updated to IAP SDK `1.4.0`.
-* Added support for gift card payments. 
+* Added support for gift card payments.
 
 ### v1.3.1 January 8, 2020
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-square-in-app-payments",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "An open source React Native plugin for calling Square’s native In-App Payments SDK to take in-app payments on iOS and Android.",
   "homepage": "https://github.com/square/in-app-payments-react-native-plugin",
   "repository": {


### PR DESCRIPTION
## Summary

Increasing version to 1.6.0 

## Related issues

Fix #

## Changelog
- Downgrading version of the IAP SDK to prevent issue where the plugin could not find certain Square methods. Will upgrade again when the issue is resolved in the IAP SDK.
