### PR TITLE
Xiao/upgrade to 1.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 ## Changelog
 
 
-### v1.7.0 Oct 27, 2021
+### v1.7.0 Oct 29, 2021
 
-* Upgrade IAP SDK to 1.5.4. 
+* Upgrade IAP SDK to `1.5.4`. 
 * Support IAP SDK version override with `$sqipVersion` for iOS or `ext.sqipVersion` for Android.
 
 ### v1.6.0 July 19, 2021
 
-* Downgrading IAP SDK to 1.4.9 to solve compatability issue with newer versions of the IAP SDK.
+* Downgrading IAP SDK to `1.4.9` to solve compatability issue with newer versions of the IAP SDK.
 
 ### v1.5.0 May 14, 2021
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 ## Changelog
 
+
+### v1.7.0 Oct 27, 2021
+
+* Upgrade IAP SDK to 1.5.4. 
+* Support IAP SDK version override with `$sqipVersion` for iOS or `ext.sqipVersion` for Android.
+
 ### v1.6.0 July 19, 2021
 
-* Downgrading IAP SDK to 1.4.9 to solve compatability issue with newer versions of the IAP SDK
+* Downgrading IAP SDK to 1.4.9 to solve compatability issue with newer versions of the IAP SDK.
 
 ### v1.5.0 May 14, 2021
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 The In-App Payments plugin for Square [In-App Payments SDK] is a wrapper for the native Android and iOS SDKs and 
 supports the following native In-App Payments SDK versions:
 
-  * iOS: `1.5.3`
-  * Android: `1.5.3`
+  * iOS: `1.5.4`
+  * Android: `1.5.4`
 
 ## Additional documentation
 
@@ -26,7 +26,7 @@ In addition to this README, the following is available in the [React Native plug
 
 ### Android
 
-* Android minSdkVersion is API 24 (Nougat, 7.0) or higher. 
+* Android minSdkVersion is API 24 (Nougat, 7.0) or higher.
 * Android Target SDK version: API 28 (Android 9).
 * Android Gradle Plugin: 3.0.0 or greater.
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 The In-App Payments plugin for Square [In-App Payments SDK] is a wrapper for the native Android and iOS SDKs and 
 supports the following native In-App Payments SDK versions:
 
-  * iOS: `1.4.0`
-  * Android: `1.4.0`
+  * iOS: `1.5.3`
+  * Android: `1.5.3`
 
 ## Additional documentation
 
@@ -26,7 +26,7 @@ In addition to this README, the following is available in the [React Native plug
 
 ### Android
 
-* Android minSdkVersion is API 21 (Lollipop, 5.0) or higher. 
+* Android minSdkVersion is API 24 (Nougat, 7.0) or higher. 
 * Android Target SDK version: API 28 (Android 9).
 * Android Gradle Plugin: 3.0.0 or greater.
 

--- a/RNSquareInAppPayments.podspec
+++ b/RNSquareInAppPayments.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNSquareInAppPayments"
-  s.version      = "1.5.1"
+  s.version      = "1.5.3"
   s.summary      = "React Native plugin for Square's In-App Payments SDK"
   s.description  = <<-DESC
                    An open source React Native plugin for calling Square’s native In-App Payments SDK to take in-app payments on iOS and Android.
@@ -17,7 +17,7 @@ Pod::Spec.new do |s|
   s.resource_bundle = { "RNSquareInAppPayments-Resources" => ["ios/RNSquareInAppPayments-Resources/*.lproj/*.strings"] }
 
   s.dependency "React"
-  s.dependency "SquareInAppPaymentsSDK", '1.4.0'
-  s.dependency 'SquareBuyerVerificationSDK', '1.3.0'
+  s.dependency "SquareInAppPaymentsSDK", '1.5.3'
+  s.dependency 'SquareBuyerVerificationSDK', '1.5.3'
 
 end

--- a/RNSquareInAppPayments.podspec
+++ b/RNSquareInAppPayments.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNSquareInAppPayments"
-  s.version      = "1.5.3"
+  s.version      = "1.5.4"
   s.summary      = "React Native plugin for Square's In-App Payments SDK"
   s.description  = <<-DESC
                    An open source React Native plugin for calling Square’s native In-App Payments SDK to take in-app payments on iOS and Android.

--- a/RNSquareInAppPayments.podspec
+++ b/RNSquareInAppPayments.podspec
@@ -17,7 +17,13 @@ Pod::Spec.new do |s|
   s.resource_bundle = { "RNSquareInAppPayments-Resources" => ["ios/RNSquareInAppPayments-Resources/*.lproj/*.strings"] }
 
   s.dependency "React"
-  s.dependency "SquareInAppPaymentsSDK", '1.5.3'
-  s.dependency 'SquareBuyerVerificationSDK', '1.5.3'
+
+  if $sqipVersion
+    s.dependency 'SquareInAppPaymentsSDK', $sqipVersion
+    s.dependency 'SquareBuyerVerificationSDK', $sqipVersion
+  else
+    s.dependency 'SquareInAppPaymentsSDK', '1.5.4'
+    s.dependency 'SquareBuyerVerificationSDK', '1.5.4'
+  end
 
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-def MIN_IAP_SDK_VERSION = '1.4.0'
+def MIN_IAP_SDK_VERSION = '1.5.3'
 
 android {
     compileSdkVersion 28

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
-def MIN_IAP_SDK_VERSION = '1.5.3'
+def MIN_IAP_SDK_VERSION = '1.5.4'
 
 android {
     compileSdkVersion 28

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -13,17 +13,15 @@ You can override the default In-App Payments SDK versions by following this guid
     # Uncomment this line to define a global platform for your project
     platform :ios, '12.0'
 
-    # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
-    ENV['COCOAPODS_DISABLE_STATS'] = 'true'
-
     # specify the version of SquareInAppPaymentsSDK
     $sqipVersion = '1.7.1'
     ```
 
 1. Remove the `ios/Podfile.lock` and build your project again.
     ```bash
-    rm ios/Podfile.lock
-    flutter run
+    cd ios
+    rm Podfile.lock
+    pod install
     ```
 
 ## Android
@@ -41,11 +39,5 @@ You can override the default In-App Payments SDK versions by following this guid
     ext {
         sqipVersion = '1.7.1'
     }
-    ```
-
-1. Clean the build and build your project again.
-    ```bash
-    flutter clean
-    flutter run
     ```
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,51 @@
+# Override the Native In-App Payments SDK Dependency Version
+
+The React Native Plugin for In-App Payments SDK by default loads a specific version of iOS and Android
+In-App Payments SDK. 
+
+You can override the default In-App Payments SDK versions by following this guidance.
+
+## iOS
+
+1. Open the `ios/Podfile` file, add the `$sqipVersion` variable and specify your desired version.
+
+    ```ruby
+    # Uncomment this line to define a global platform for your project
+    platform :ios, '12.0'
+
+    # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+    ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+    # specify the version of SquareInAppPaymentsSDK
+    $sqipVersion = '1.7.1'
+    ```
+
+1. Remove the `ios/Podfile.lock` and build your project again.
+    ```bash
+    rm ios/Podfile.lock
+    flutter run
+    ```
+
+## Android
+
+1. Open the `android/build.gradle` file, add the `sqipVersion` variable and specify your desired version.
+    ```gradle
+    allprojects {
+        repositories {
+            google()
+            jcenter()
+        }
+    }
+
+    // add the override here
+    ext {
+        sqipVersion = '1.7.1'
+    }
+    ```
+
+1. Clean the build and build your project again.
+    ```bash
+    flutter clean
+    flutter run
+    ```
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-square-in-app-payments",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "An open source React Native plugin for calling Square’s native In-App Payments SDK to take in-app payments on iOS and Android.",
   "homepage": "https://github.com/square/in-app-payments-react-native-plugin",
   "repository": {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/in-app-payments-react-native-plugin/blob/master/CONTRIBUTING.md
-->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Upgrade IAP SDK to 1.5.4

## Related issues

N/A

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. See https://github.com/square/in-app-payments-react-native-plugin/blob/master/CHANGELOG.md for an example. -->

* IAP SDK upgraded to 1.5.4
* Support sqipVersion override (iOS didn't support it)
* updated the Readme
* bump the plugin version
* add change log 

## Test Plan

<!-- Demonstrate the code is solid. Example: Manually test the quick start example works. -->
Tested in local environment on emulator. Didn't use quick start app to test given it's broken, created a new react-native app and tested.