### PR TITLE
[Android] play-services-wallet gradle dependency SDK upgraded

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -47,5 +47,5 @@ dependencies {
     implementation "com.squareup.sdk.in-app-payments:card-entry:$sqipVersion"
     implementation "com.squareup.sdk.in-app-payments:google-pay:$sqipVersion"
     implementation "com.squareup.sdk.in-app-payments:buyer-verification:$sqipVersion"
-    implementation 'com.google.android.gms:play-services-wallet:16.0.1'
+    implementation 'com.google.android.gms:play-services-wallet:17.0.0'
 }


### PR DESCRIPTION
This PR will resolve the [Outdated play-service-maps SDK](https://github.com/square/in-app-payments-react-native-plugin/issues/231) issue.