### PR TITLE
Add a github action to publish to NPM.js.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,12 +24,12 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
       - name: Cache Gradle Wrapper
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
       - name: Cache Gradle Dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-caches-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,7 +1,7 @@
 # This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
-name: react-native-square-reader-sdk
+name: react-native-square-in-app-payments
 
 on:
   push:

--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,0 +1,29 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: react-native-square-reader-sdk
+
+on:
+  push:
+    tags:
+    # matches 'v{{version}}', e.g. v1.4.3
+    - 'v[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm i
+      - run: npm pack    
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   "devDependencies": {
     "@types/jest": "^26.0.23",
     "@types/node": "^17.0.23",
-    "@types/react": "^17.0.11",
-    "@types/react-native": "^0.64.10",
-    "@types/react-test-renderer": "^17.0.1",
+    "@types/react": "^18.2.6",
+    "@types/react-native": "^0.72.0",
+    "@types/react-test-renderer": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^4.29.2",
     "babel-eslint": "^10.1.0",
     "babel-jest": "27.0.1",
@@ -41,7 +41,7 @@
     "metro-react-native-babel-preset": "0.56.0",
     "react": "18.2.0",
     "react-native": "0.74.1",
-    "react-test-renderer": "16.9.0",
+    "react-test-renderer": "18.2.0",
     "ts-jest": "^27.0.3",
     "typescript": "^4.3.5"
   },


### PR DESCRIPTION
Add a github action to publish to NPM.js.
Fix dependency issues in package.json.

## Summary

Add a new action in .github to publish to NPM.JS. This still needs some configuration in our repo, but it's the first step. Also, fixed some dependency issues found when testing the script.

## Related issues

N/A

## Changelog

Added npm-publish-github-packages.yml.
Modified package.json.

## Test Plan

Run the steps in the GH action in my computer with the `--dry-run` option