### PR TITLE
fix warning new NativeEventEmitter()

### DIFF
--- a/android/src/main/java/sqip/react/CardEntryModule.java
+++ b/android/src/main/java/sqip/react/CardEntryModule.java
@@ -323,4 +323,14 @@ class CardEntryModule extends ReactContextBaseJavaModule {
     }
     return deviceEventEmitter;
   }
+  
+  @ReactMethod
+  public void addListener(String eventName) {
+
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+
+  }
 }

--- a/android/src/main/java/sqip/react/GooglePayModule.java
+++ b/android/src/main/java/sqip/react/GooglePayModule.java
@@ -185,4 +185,13 @@ class GooglePayModule extends ReactContextBaseJavaModule {
     }
     return deviceEventEmitter;
   }
+  @ReactMethod
+  public void addListener(String eventName) {
+
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+
+  }
 }

--- a/react-native-in-app-payments-quickstart/index.js
+++ b/react-native-in-app-payments-quickstart/index.js
@@ -24,4 +24,3 @@ AppRegistry.registerComponent(appName, () => App);
 A lot of libraries still haven't released a new version to handle
 these errors (or warnings in some cases).
 so we can hide the warning for now with this logBox. */
-LogBox.ignoreAllLogs();


### PR DESCRIPTION


## Summary

it is solving warning of new NativeEventEmitter()  after adding the lib

## Related issues

Fix #

## Changelog

adding methods to android modules

* message 

## Test Plan