### PR TITLE
fix: add prepack script to generate lib/ before publishing

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -22,8 +22,20 @@ jobs:
         with:
           node-version: '20.x'
           registry-url: 'https://registry.npmjs.org'
-      - run: npm i
-      - run: npm pack    
-      - run: npm publish --provenance --access public
+          cache: 'yarn'
+
+      # Use Yarn instead of npm
+      - name: Enable corepack (Yarn)
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Build package tarball with Yarn
+        run: yarn pack --out package.tgz
+
+      # Still use npm to publish the already-generated tarball
+      - name: Publish to npm
+        run: npm publish package.tgz --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "clean": "del-cli android/build example/android/build example/android/app/build example/ios/build example/ios/Pods lib example-expo/ios/build example-expo/android/build example-expo/android/app/build example-expo/ios/Pods",
     "prepare": "bob build",
+    "prepack": "bob build",
     "release": "release-it --only-version"
   },
   "keywords": [


### PR DESCRIPTION
<!--
Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request.

We can only accept your change after you sign this Individual Contributor License Agreement (CLA), you'll get the CLA link after create PR.

Learn more about the contributing rules from https://github.com/square/in-app-payments-react-native-plugin/blob/master/CONTRIBUTING.md
-->

## Summary

Yarn Berry does not automatically run the `prepare` script during `yarn pack`. This causes the `lib/` directory (generated by `bob build`) to be missing from the published npm package, resulting in the error:

> The resolution for "react-native-square-in-app-payments" defined in "exports" is lib/module/index.js, however this file does not exist.

This PR adds a `prepack` script that explicitly runs `bob build` before the tarball is created, ensuring the `lib/` directory is included in the published package.

**Note:** This PR is based on `v2.0.0` tag and includes commit 3b19f0e ("update publish pipeline") which was not merged to master.

## Related issues

Fix #259

## Changelog

* Fixed missing `lib/` directory in published npm package by adding `prepack` script

## Test Plan

1. Run `yarn pack` and verify that `lib/` directory is included in the generated tarball
2. Verify the tarball contains `lib/module/index.js` and `lib/typescript/src/index.d.ts`
