### PR TITLE
Bump IAP SDK to Android 1.6.8 / iOS 1.6.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### v2.0.1 Jun 4, 2026
+
+* Upgrade IAP SDK for Android `1.6.8` and for iOS `1.6.6`.
+
 ### v1.7.6 Jun 03, 2024
 
 * Upgrade IAP SDK for Android `1.6.6` and for iOS `1.6.3`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v2.0.1 Jun 4, 2026
 
-* Upgrade IAP SDK for Android `1.6.8` and for iOS `1.6.6`.
+* Upgrade IAP SDK for Android `1.6.8` and for iOS `1.6.7`.
 
 ### v1.7.6 Jun 03, 2024
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The In-App Payments plugin for Square [In-App Payments SDK] is a wrapper for the native Android and iOS SDKs and 
 supports the following native In-App Payments SDK versions:
 
-  * iOS: `1.6.6`
+  * iOS: `1.6.7`
   * Android: `1.6.8`
 
 ## Additional documentation

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 The In-App Payments plugin for Square [In-App Payments SDK] is a wrapper for the native Android and iOS SDKs and 
 supports the following native In-App Payments SDK versions:
 
-  * iOS: `1.6.5`
+  * iOS: `1.6.6`
   * Android: `1.6.8`
 
 ## Additional documentation

--- a/SquareInAppPayments.podspec
+++ b/SquareInAppPayments.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     s.dependency 'SquareInAppPaymentsSDK', $sqipVersion
     s.dependency 'SquareBuyerVerificationSDK', $sqipVersion
   else
-    s.dependency 'SquareInAppPaymentsSDK', '1.6.5'
-    s.dependency 'SquareBuyerVerificationSDK', '1.6.5'
+    s.dependency 'SquareInAppPaymentsSDK', '1.6.6'
+    s.dependency 'SquareBuyerVerificationSDK', '1.6.6'
   end
 end

--- a/SquareInAppPayments.podspec
+++ b/SquareInAppPayments.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     s.dependency 'SquareInAppPaymentsSDK', $sqipVersion
     s.dependency 'SquareBuyerVerificationSDK', $sqipVersion
   else
-    s.dependency 'SquareInAppPaymentsSDK', '1.6.6'
-    s.dependency 'SquareBuyerVerificationSDK', '1.6.6'
+    s.dependency 'SquareInAppPaymentsSDK', '1.6.7'
+    s.dependency 'SquareBuyerVerificationSDK', '1.6.7'
   end
 end

--- a/ios/internal/SQIPBuyerInternal.m
+++ b/ios/internal/SQIPBuyerInternal.m
@@ -37,49 +37,63 @@ static BOOL _shouldContinueWithApplePayNonceRequest = NO;
         [SQIPBuyerAction fromStringDictionary:buyerActionString money:moneyMap];
     SQIPContact *contact = [SQIPContact fromDictionary:contactMap];
 
-    UIViewController *rootViewController =
-        [UiUtilities activeRootViewController];
-
     SQIPVerificationParameters *params = [[SQIPVerificationParameters alloc]
         initWithPaymentSourceID:paymentSourceId
                     buyerAction:buyerAction
                      locationID:locationId
                         contact:contact];
 
-    if ([rootViewController isKindOfClass:[UINavigationController class]]) {
-      [rootViewController.navigationController popViewControllerAnimated:YES];
-    } else {
-      [rootViewController dismissViewControllerAnimated:YES completion:nil];
-    }
-
-    [SQIPBuyerVerificationSDK.shared verifyWithParameters:params
-        theme:[SQIPCardEntryInternal theme]
-        viewController:rootViewController
-        success:^(SQIPBuyerVerifiedDetails *_Nonnull verifiedDetails) {
-          NSDictionary *verificationResult = @{
-            @"nonce" : paymentSourceId,
-            @"token" : verifiedDetails.verificationToken
-          };
-          onBuyerVerificationSuccess(@[ verificationResult ]);
-          [SQIPBuyerInternal shouldContinue];
-        }
-        failure:^(NSError *_Nonnull error) {
-          NSString *debugCode = error.userInfo[SQIPErrorDebugCodeKey];
-          NSString *debugMessage = error.userInfo[SQIPErrorDebugMessageKey];
-          if (_mockBuyerVerification) {
-            NSDictionary *verificationResult =
-                @{@"nonce" : paymentSourceId, @"token" : @"mock-token"};
+    // Capture the success/failure blocks so we can present from the dismissal
+    // completion handler. We need to wait for any in-progress dismissal to
+    // finish before handing 3DS_SDK a presenter — otherwise it tries to
+    // present on a VC whose view is mid-removal from the window hierarchy,
+    // which surfaces as "view is not in the window hierarchy" under the new
+    // React Native architecture (RCTFabricModalHostViewController).
+    void (^presentVerification)(void) = ^{
+      UIViewController *presenter = [UiUtilities activeRootViewController];
+      [SQIPBuyerVerificationSDK.shared verifyWithParameters:params
+          theme:[SQIPCardEntryInternal theme]
+          viewController:presenter
+          success:^(SQIPBuyerVerifiedDetails *_Nonnull verifiedDetails) {
+            NSDictionary *verificationResult = @{
+              @"nonce" : paymentSourceId,
+              @"token" : verifiedDetails.verificationToken
+            };
             onBuyerVerificationSuccess(@[ verificationResult ]);
             [SQIPBuyerInternal shouldContinue];
-          } else {
-            [SQIPBuyerInternal invalidateShouldContinue];
-            onBuyerVerificationFailure(@[ [ErrorUtilities
-                callbackErrorObject:RNSQIPUsageError
-                            message:error.localizedDescription
-                          debugCode:debugCode
-                       debugMessage:debugMessage] ]);
           }
-        }];
+          failure:^(NSError *_Nonnull error) {
+            NSString *debugCode = error.userInfo[SQIPErrorDebugCodeKey];
+            NSString *debugMessage = error.userInfo[SQIPErrorDebugMessageKey];
+            if (_mockBuyerVerification) {
+              NSDictionary *verificationResult =
+                  @{@"nonce" : paymentSourceId, @"token" : @"mock-token"};
+              onBuyerVerificationSuccess(@[ verificationResult ]);
+              [SQIPBuyerInternal shouldContinue];
+            } else {
+              [SQIPBuyerInternal invalidateShouldContinue];
+              onBuyerVerificationFailure(@[ [ErrorUtilities
+                  callbackErrorObject:RNSQIPUsageError
+                              message:error.localizedDescription
+                            debugCode:debugCode
+                         debugMessage:debugMessage] ]);
+            }
+          }];
+    };
+
+    UIViewController *activeViewController =
+        [UiUtilities activeRootViewController];
+
+    // If a modal (e.g. card entry) is on top, dismiss it first and only
+    // present verification once dismissal completes — `presentingViewController`
+    // is the VC the active modal will hand control back to.
+    if (activeViewController.presentingViewController != nil) {
+      [activeViewController.presentingViewController
+          dismissViewControllerAnimated:YES
+                             completion:presentVerification];
+    } else {
+      presentVerification();
+    }
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-square-in-app-payments",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An open source React Native plugin for calling Square’s native In-App Payments SDK to take in-app payments on iOS and Android.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
## Summary
Bump bundled In-App Payments SDK versions:
- iOS: `1.6.5` → `1.6.7`
- Android: already at `1.6.8` in `android/gradle.properties`; updated documentation accordingly

iOS 1.6.6 updates the bundled NetceteraSDK to 2.5.1.0 to address the Visa Device Data Encryption Certificate expiration on 2026-06-08. iOS 1.6.7 is a follow-up patch on top of 1.6.6 that fixes public-header imports in the shipped `SquareInAppPaymentsSDK` and `SquareBuyerVerificationSDK` xcframeworks — system-framework imports were using `@import` module syntax, which fails to resolve in some third-party consumer build contexts. 1.6.7 switches them to `#import <Framework/Framework.h>`, which works in both module and non-module contexts.

## Changes
- `SquareInAppPayments.podspec` — `SquareInAppPaymentsSDK` / `SquareBuyerVerificationSDK` fallback `1.6.5` → `1.6.7`
- `README.md` — supported iOS version `1.6.5` → `1.6.7`
- `package.json` — plugin version `2.0.0` → `2.0.1`
- `CHANGELOG.md` — new `v2.0.1` entry
- `ios/internal/SQIPBuyerInternal.m` — fix a pre-existing race where `SQIPBuyerVerificationSDK.shared.verifyWithParameters:viewController:` was handed a presenter whose dismissal was still in flight. Under the new React Native architecture, `RCTFabricModalHostViewController` enforces an in-window-hierarchy check and refuses to be a presenter mid-dismissal, surfacing as `Attempt to present ThreeDS_SDK.CustomizedNavController ... whose view is not in the window hierarchy`. Now we wait for `dismissViewControllerAnimated:completion:` to finish, re-query `activeRootViewController`, and present the verification flow from inside the completion block.
