### PR TITLE
Bump IAP SDK to Android 1.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### v2.0.1 Jun 4, 2026
 
-* Upgrade IAP SDK for Android `1.6.8` and for iOS `1.6.7`.
+* Upgrade IAP SDK for Android `1.6.9` and for iOS `1.6.7`.
 
 ### v1.7.6 Jun 03, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### v2.0.1 Jun 4, 2026
 
 * Upgrade IAP SDK for Android `1.6.9` and for iOS `1.6.7`.
+* IAP SDK Android `1.6.9` ships Kotlin 2.3.0 metadata, which the Kotlin 2.1.x compiler pinned by current React Native cannot read. The plugin now compiles itself with a Kotlin 2.2 compiler when it detects an older Kotlin Gradle plugin, and keeps the SDK's `kotlin-stdlib` 2.3.0 off the consumer's compile classpath — no changes needed in consuming apps.
+* IAP SDK Android `1.6.9` pulls in OkHttp 5.x, whose multi-release jars ship duplicate `META-INF/versions/9/OSGI-INF/MANIFEST.MF` entries and fail `mergeJavaResource`. The Expo config plugin now excludes it automatically; bare React Native apps should add a `packaging` exclude to `android/app/build.gradle` (see the [getting started guide](docs/get-started.md)).
 
 ### v1.7.6 Jun 03, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### v2.0.1 Jun 4, 2026
 
 * Upgrade IAP SDK for Android `1.6.9` and for iOS `1.6.7`.
-* IAP SDK Android `1.6.9` ships Kotlin 2.3.0 metadata, which the Kotlin 2.1.x compiler pinned by current React Native cannot read. The plugin now compiles itself with a Kotlin 2.2 compiler when it detects an older Kotlin Gradle plugin, and keeps the SDK's `kotlin-stdlib` 2.3.0 off the consumer's compile classpath — no changes needed in consuming apps.
+* IAP SDK Android `1.6.9` is built with Kotlin 2.3.0 and requires Kotlin `2.2.21`+ to compile, while React Native pins Kotlin 2.1.x (as of RN 0.86). The Expo config plugin now pins the Kotlin Gradle plugin to `2.2.21` automatically; bare React Native apps must pin it in their root `android/build.gradle` (see the [getting started guide](docs/get-started.md)).
 * IAP SDK Android `1.6.9` pulls in OkHttp 5.x, whose multi-release jars ship duplicate `META-INF/versions/9/OSGI-INF/MANIFEST.MF` entries and fail `mergeJavaResource`. The Expo config plugin now excludes it automatically; bare React Native apps should add a `packaging` exclude to `android/app/build.gradle` (see the [getting started guide](docs/get-started.md)).
 
 ### v1.7.6 Jun 03, 2024

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ supports the following native In-App Payments SDK versions:
   * iOS: `1.6.7`
   * Android: `1.6.9`
 
+<!-- TODO(kotlin-2.2-workaround): delete this section once the minimum
+supported React Native ships Kotlin 2.2+ (facebook/react-native#56838,
+expected in RN 0.87). -->
 ## Android: Kotlin 2.2.x compatibility
 
 In-App Payments Android SDK `1.6.9` is built with Kotlin 2.3.0 and requires Kotlin `2.2.21`+ to compile, which React Native does not ship yet (it pins Kotlin 2.1.x as of RN 0.86). The Expo config plugin handles this automatically; bare React Native apps must pin the Kotlin Gradle plugin in their root `android/build.gradle` — see the [getting started guide](docs/get-started.md#step-4-configure-your-android-project).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The In-App Payments plugin for Square [In-App Payments SDK] is a wrapper for the
 supports the following native In-App Payments SDK versions:
 
   * iOS: `1.6.7`
-  * Android: `1.6.8`
+  * Android: `1.6.9`
 
 ## Additional documentation
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ supports the following native In-App Payments SDK versions:
   * iOS: `1.6.7`
   * Android: `1.6.9`
 
+## Android: Kotlin 2.2.x compatibility
+
+In-App Payments Android SDK `1.6.9` is built with Kotlin 2.3.0 and requires Kotlin `2.2.21`+ to compile, which React Native does not ship yet (it pins Kotlin 2.1.x as of RN 0.86). The Expo config plugin handles this automatically; bare React Native apps must pin the Kotlin Gradle plugin in their root `android/build.gradle` — see the [getting started guide](docs/get-started.md#step-4-configure-your-android-project).
+
 ## Additional documentation
 
 In addition to this README, the following is available in the [React Native plugin GitHub repo]:

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,31 +79,6 @@ rootProject.allprojects {
   }
 }
 
-// IAP SDK 1.6.9+ ships Kotlin 2.3.0 metadata, which Kotlin compilers older
-// than 2.2 cannot read. React Native's gradle plugin currently pins Kotlin
-// 2.1.x for ALL modules (its KGP sits on the settings classpath, so root-level
-// kotlinVersion overrides do not change the actual compiler). When we detect
-// such a KGP, swap in a compiler that can read the SDK, without requiring
-// consumers to change their Kotlin/RN setup. Self-disables once RN moves to
-// Kotlin 2.2+.
-def kgpVersion = org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapperKt.getKotlinPluginVersion(project)
-def kgpCannotReadSqipMetadata = kgpVersion.matches(/^(1\.|2\.[01]\.).*/)
-if (kgpCannotReadSqipMetadata) {
-  configurations.matching { it.name == "kotlinCompilerClasspath" }.all {
-    resolutionStrategy.eachDependency { details ->
-      if (details.requested.group == "org.jetbrains.kotlin" && details.requested.name == "kotlin-compiler-embeddable") {
-        details.useVersion "2.2.20"
-      }
-    }
-  }
-  // The newer compiler cannot talk to the Kotlin daemon spawned by the older
-  // Kotlin gradle plugin, so run it inside the Gradle process instead.
-  def inProcessStrategy = org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy.IN_PROCESS
-  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
-    compilerExecutionStrategy.set(inProcessStrategy)
-  }
-}
-
 def kotlin_version = getExtOrDefault("kotlinVersion")
 def sqipVersion = getExtOrDefault("sqipVersion")
 def googlePayVersion = getExtOrDefault("googlePayVersion")
@@ -112,17 +87,7 @@ dependencies {
   implementation "com.facebook.react:react-android"
   implementation "com.google.android.gms:play-services-wallet:$googlePayVersion"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  // IAP SDK 1.6.9+ depends on kotlin-stdlib 2.3.0, whose metadata the Kotlin
-  // 2.1.x compiler shipped with current React Native cannot read. Keep it off
-  // the consumer's compile classpath; the stdlib is backwards compatible at
-  // runtime, so the consumer's (older) stdlib satisfies it.
-  implementation("com.squareup.sdk.in-app-payments:card-entry:$sqipVersion") {
-    exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
-  }
-  implementation("com.squareup.sdk.in-app-payments:google-pay:$sqipVersion") {
-    exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
-  }
-  implementation("com.squareup.sdk.in-app-payments:buyer-verification:$sqipVersion") {
-    exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
-  }
+  implementation "com.squareup.sdk.in-app-payments:card-entry:$sqipVersion"
+  implementation "com.squareup.sdk.in-app-payments:google-pay:$sqipVersion"
+  implementation "com.squareup.sdk.in-app-payments:buyer-verification:$sqipVersion"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -79,6 +79,31 @@ rootProject.allprojects {
   }
 }
 
+// IAP SDK 1.6.9+ ships Kotlin 2.3.0 metadata, which Kotlin compilers older
+// than 2.2 cannot read. React Native's gradle plugin currently pins Kotlin
+// 2.1.x for ALL modules (its KGP sits on the settings classpath, so root-level
+// kotlinVersion overrides do not change the actual compiler). When we detect
+// such a KGP, swap in a compiler that can read the SDK, without requiring
+// consumers to change their Kotlin/RN setup. Self-disables once RN moves to
+// Kotlin 2.2+.
+def kgpVersion = org.jetbrains.kotlin.gradle.plugin.KotlinPluginWrapperKt.getKotlinPluginVersion(project)
+def kgpCannotReadSqipMetadata = kgpVersion.matches(/^(1\.|2\.[01]\.).*/)
+if (kgpCannotReadSqipMetadata) {
+  configurations.matching { it.name == "kotlinCompilerClasspath" }.all {
+    resolutionStrategy.eachDependency { details ->
+      if (details.requested.group == "org.jetbrains.kotlin" && details.requested.name == "kotlin-compiler-embeddable") {
+        details.useVersion "2.2.20"
+      }
+    }
+  }
+  // The newer compiler cannot talk to the Kotlin daemon spawned by the older
+  // Kotlin gradle plugin, so run it inside the Gradle process instead.
+  def inProcessStrategy = org.jetbrains.kotlin.gradle.tasks.KotlinCompilerExecutionStrategy.IN_PROCESS
+  tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    compilerExecutionStrategy.set(inProcessStrategy)
+  }
+}
+
 def kotlin_version = getExtOrDefault("kotlinVersion")
 def sqipVersion = getExtOrDefault("sqipVersion")
 def googlePayVersion = getExtOrDefault("googlePayVersion")
@@ -87,7 +112,17 @@ dependencies {
   implementation "com.facebook.react:react-android"
   implementation "com.google.android.gms:play-services-wallet:$googlePayVersion"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-  implementation "com.squareup.sdk.in-app-payments:card-entry:$sqipVersion"
-  implementation "com.squareup.sdk.in-app-payments:google-pay:$sqipVersion"
-  implementation "com.squareup.sdk.in-app-payments:buyer-verification:$sqipVersion"
+  // IAP SDK 1.6.9+ depends on kotlin-stdlib 2.3.0, whose metadata the Kotlin
+  // 2.1.x compiler shipped with current React Native cannot read. Keep it off
+  // the consumer's compile classpath; the stdlib is backwards compatible at
+  // runtime, so the consumer's (older) stdlib satisfies it.
+  implementation("com.squareup.sdk.in-app-payments:card-entry:$sqipVersion") {
+    exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
+  }
+  implementation("com.squareup.sdk.in-app-payments:google-pay:$sqipVersion") {
+    exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
+  }
+  implementation("com.squareup.sdk.in-app-payments:buyer-verification:$sqipVersion") {
+    exclude group: "org.jetbrains.kotlin", module: "kotlin-stdlib"
+  }
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-SquareInAppPayments_kotlinVersion=2.2.20
+SquareInAppPayments_kotlinVersion=2.2.21
 SquareInAppPayments_minSdkVersion=28
 SquareInAppPayments_targetSdkVersion=36
 SquareInAppPayments_compileSdkVersion=36

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,6 @@
+# TODO(kotlin-2.2-workaround): 2.2.21 is required to read IAP SDK 1.6.9+
+# metadata. Once the minimum supported React Native ships Kotlin 2.2+
+# (facebook/react-native#56838), this can track RN's Kotlin again.
 SquareInAppPayments_kotlinVersion=2.2.21
 SquareInAppPayments_minSdkVersion=28
 SquareInAppPayments_targetSdkVersion=36

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -3,5 +3,5 @@ SquareInAppPayments_minSdkVersion=28
 SquareInAppPayments_targetSdkVersion=36
 SquareInAppPayments_compileSdkVersion=36
 SquareInAppPayments_ndkVersion=27.1.12297006
-SquareInAppPayments_sqipVersion=1.6.8
+SquareInAppPayments_sqipVersion=1.6.9
 SquareInAppPayments_googlePayVersion=19.2.1

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,4 +1,4 @@
-SquareInAppPayments_kotlinVersion=2.0.21
+SquareInAppPayments_kotlinVersion=2.2.20
 SquareInAppPayments_minSdkVersion=28
 SquareInAppPayments_targetSdkVersion=36
 SquareInAppPayments_compileSdkVersion=36

--- a/android/src/main/java/com/squareinapppayments/modules/SQIPBuyerModule.kt
+++ b/android/src/main/java/com/squareinapppayments/modules/SQIPBuyerModule.kt
@@ -17,7 +17,7 @@ class SQIPBuyerModule(reactContext: ReactApplicationContext) :
   }
 
   init {
-    SQIPBuyer.setActivity(currentActivity)
+    SQIPBuyer.setActivity(getCurrentActivity())
     SQIPBuyer.setReactApplicationContext(reactApplicationContext)
   }
 

--- a/android/src/main/java/com/squareinapppayments/modules/SQIPCardEntryModule.kt
+++ b/android/src/main/java/com/squareinapppayments/modules/SQIPCardEntryModule.kt
@@ -14,7 +14,7 @@ class SQIPCardEntryModule(reactContext: ReactApplicationContext) :
 
   init {
     SQIPCardEntry.setReactApplicationContext(reactApplicationContext)
-    SQIPCardEntry.setActivity(currentActivity)
+    SQIPCardEntry.setActivity(getCurrentActivity())
   }
 
   override fun getName(): String {

--- a/android/src/main/java/com/squareinapppayments/modules/SQIPGooglePayModule.kt
+++ b/android/src/main/java/com/squareinapppayments/modules/SQIPGooglePayModule.kt
@@ -19,7 +19,7 @@ class SQIPGooglePayModule(reactContext: ReactApplicationContext) :
 
   init {
     SQIPGooglePay.setReactApplicationContext(reactApplicationContext)
-    SQIPGooglePay.setActivity(currentActivity)
+    SQIPGooglePay.setActivity(getCurrentActivity())
   }
 
   override fun initializeGooglePay(

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -19,7 +19,10 @@ const EDIT_TEXT_STYLE_PARENT = 'Widget.AppCompat.EditText';
 const SAVE_BUTTON_STYLE_NAME = 'sqip.Theme.CardEntry.SaveButton';
 const SAVE_BUTTON_STYLE_PARENT = 'Widget.AppCompat.Button.Colored';
 const PLUGIN_PREFIX = 'sqip_card_entry_';
-// Minimum Kotlin version able to read IAP SDK 1.6.9+ metadata (Kotlin 2.3.0).
+// TODO(kotlin-2.2-workaround): Minimum Kotlin version able to read IAP SDK
+// 1.6.9+ metadata (Kotlin 2.3.0). Remove this constant and the KGP pin below
+// once the minimum supported React Native ships Kotlin 2.2+ — merged to RN
+// main in facebook/react-native#56838 (May 2026), expected in RN 0.87.
 const SQIP_KOTLIN_VERSION = '2.2.21';
 
 const COLOR_MAPPINGS = [
@@ -283,6 +286,8 @@ function withSquarePaymentsSDK(config, opts = {}) {
         if (mod.modResults.language !== 'groovy') return mod;
         let src = mod.modResults.contents || '';
 
+        // TODO(kotlin-2.2-workaround): remove this replace() once the minimum
+        // supported React Native ships Kotlin 2.2+ (facebook/react-native#56838).
         // IAP SDK 1.6.9+ is built with Kotlin 2.3.0 and requires a Kotlin
         // 2.2+ compiler. Expo's generated root build.gradle declares the
         // Kotlin Gradle plugin without a version, which resolves to the

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -19,6 +19,8 @@ const EDIT_TEXT_STYLE_PARENT = 'Widget.AppCompat.EditText';
 const SAVE_BUTTON_STYLE_NAME = 'sqip.Theme.CardEntry.SaveButton';
 const SAVE_BUTTON_STYLE_PARENT = 'Widget.AppCompat.Button.Colored';
 const PLUGIN_PREFIX = 'sqip_card_entry_';
+// Minimum Kotlin version able to read IAP SDK 1.6.9+ metadata (Kotlin 2.3.0).
+const SQIP_KOTLIN_VERSION = '2.2.21';
 
 const COLOR_MAPPINGS = [
   {
@@ -280,6 +282,17 @@ function withSquarePaymentsSDK(config, opts = {}) {
       cfg = withProjectBuildGradle(cfg, (mod) => {
         if (mod.modResults.language !== 'groovy') return mod;
         let src = mod.modResults.contents || '';
+
+        // IAP SDK 1.6.9+ is built with Kotlin 2.3.0 and requires a Kotlin
+        // 2.2+ compiler. Expo's generated root build.gradle declares the
+        // Kotlin Gradle plugin without a version, which resolves to the
+        // Kotlin pinned by React Native (2.1.x as of RN 0.86) and cannot
+        // read the SDK's metadata. Pin a compatible version explicitly.
+        src = src.replace(
+          /classpath\((['"])org\.jetbrains\.kotlin:kotlin-gradle-plugin\1\)/,
+          `classpath('org.jetbrains.kotlin:kotlin-gradle-plugin:${SQIP_KOTLIN_VERSION}')`
+        );
+
         const SQUARE_REPO_URL = 'https://sdk.squareup.com/public/android';
         const SQUARE_REPO_REGEX =
           /maven\s*{\s*url\s*['"]https:\/\/sdk\.squareup\.com\/public\/android['"]\s*}/;

--- a/app.plugin.js
+++ b/app.plugin.js
@@ -1,6 +1,7 @@
 const configPlugins = require('@expo/config-plugins');
 const {
   withProjectBuildGradle,
+  withAppBuildGradle,
   withXcodeProject,
   createRunOncePlugin,
   withAndroidStyles,
@@ -304,6 +305,25 @@ function withSquarePaymentsSDK(config, opts = {}) {
         }
         mod.modResults.contents = src;
 
+        return mod;
+      });
+
+      //
+      // 🟢 ANDROID PART 1b exclude duplicate OkHttp multi-release jar manifest
+      //
+      // IAP SDK 1.6.9+ pulls in OkHttp 5.x, whose multi-release jars
+      // (logging-interceptor, jspecify) both ship
+      // META-INF/versions/9/OSGI-INF/MANIFEST.MF, which fails
+      // mergeJavaResource with a duplicate-file error.
+      cfg = withAppBuildGradle(cfg, (mod) => {
+        if (mod.modResults.language !== 'groovy') return mod;
+        const src = mod.modResults.contents || '';
+        const EXCLUDED_RESOURCE = 'META-INF/versions/9/OSGI-INF/MANIFEST.MF';
+        if (src.includes(EXCLUDED_RESOURCE)) return mod;
+        mod.modResults.contents = src.replace(
+          /android\s*\{/,
+          `android {\n    packaging {\n        resources {\n            excludes += "${EXCLUDED_RESOURCE}"\n        }\n    }\n`
+        );
         return mod;
       });
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -145,6 +145,22 @@ are just examples.
     }
     ```
 
+1. In-App Payments Android SDK `1.6.9` and newer depend on OkHttp 5.x, whose
+multi-release jars each ship `META-INF/versions/9/OSGI-INF/MANIFEST.MF`. This
+fails the `mergeJavaResource` task with a duplicate-file error. If you use the
+Expo config plugin this is handled for you; otherwise add the following to
+`android/app/build.gradle`:
+
+    ```gradle
+    android {
+      packaging {
+        resources {
+          excludes += "META-INF/versions/9/OSGI-INF/MANIFEST.MF"
+        }
+      }
+    }
+    ```
+
 ## Card Entry Usage
 Complete the following steps to add the **In-App Payments** card entry screen to
 your React Native project and use the card entry screen to get a nonce.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -139,7 +139,7 @@ are just examples.
           compileSdkVersion = 33
           targetSdkVersion = 33
           supportLibVersion = "33.0.0"
-          sqipVersion="1.6.8"
+          sqipVersion="1.6.9"
       }
       ...
     }

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -145,6 +145,30 @@ are just examples.
     }
     ```
 
+1. In-App Payments Android SDK `1.6.9` and newer are built with Kotlin 2.3.0
+and require Kotlin `2.2.21` or newer to compile. React Native's gradle plugin
+pins an older Kotlin (2.1.x as of RN 0.86), so builds fail with
+`Module was compiled with an incompatible version of Kotlin`. If you use the
+Expo config plugin this is handled for you; otherwise pin the Kotlin Gradle
+plugin version in your root `android/build.gradle`:
+
+    ```gradle
+    buildscript {
+      ext {
+          ...
+          kotlinVersion = "2.2.21"
+      }
+      dependencies {
+          ...
+          classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+      }
+    }
+    ```
+
+    > The version must be on the `classpath` line — a versionless
+    > `kotlin-gradle-plugin` entry resolves to React Native's pinned Kotlin
+    > even when `ext.kotlinVersion` is set.
+
 1. In-App Payments Android SDK `1.6.9` and newer depend on OkHttp 5.x, whose
 multi-release jars each ship `META-INF/versions/9/OSGI-INF/MANIFEST.MF`. This
 fails the `mergeJavaResource` task with a duplicate-file error. If you use the

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -145,6 +145,9 @@ are just examples.
     }
     ```
 
+<!-- TODO(kotlin-2.2-workaround): delete this step once the minimum supported
+React Native ships Kotlin 2.2+ (facebook/react-native#56838, expected in
+RN 0.87). -->
 1. In-App Payments Android SDK `1.6.9` and newer are built with Kotlin 2.3.0
 and require Kotlin `2.2.21` or newer to compile. React Native's gradle plugin
 pins an older Kotlin (2.1.x as of RN 0.86), so builds fail with


### PR DESCRIPTION
Bumps the In-App Payments SDK Android dependency to `1.6.9` — which turned out not to be a drop-in upgrade for React Native.

## Not a drop-in upgrade

Building the `example-expo` app against 1.6.9 surfaced two problems:

**1. Kotlin metadata incompatibility.** The 1.6.9 artifacts were compiled with Kotlin 2.3.0, whose metadata Kotlin compilers older than 2.2 cannot read. React Native pins Kotlin 2.1.20 — even on the latest RN 0.86 — so every stock RN/Expo app fails to compile with "Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.3.0, expected version is 2.1.0." Bumping RN does not help; no RN release ships Kotlin 2.2+.

The fix is the same one the MPSDK wrapper uses (square/mobile-payments-sdk-react-native, `docs/KOTLIN_COMPATIBILITY.md`): require Kotlin `2.2.21` and pin the Kotlin Gradle plugin version explicitly. The key subtlety: the version must be on the `classpath` line of the root `build.gradle` — the generated template declares `classpath('org.jetbrains.kotlin:kotlin-gradle-plugin')` versionless, which resolves to RN's pinned Kotlin regardless of `ext.kotlinVersion` or `expo-build-properties`.

**2. OkHttp 5.x packaging conflict.** 1.6.9 pulls in OkHttp 5.3.2, whose multi-release jars ship duplicate `META-INF/versions/9/OSGI-INF/MANIFEST.MF` entries and fail `mergeJavaResource` — same issue the Flutter plugin hit in square/in-app-payments-flutter-plugin#286.

## Changes

- `android/gradle.properties` — `sqipVersion` `1.6.8` -> `1.6.9`; fallback `kotlinVersion` `2.0.21` -> `2.2.21`
- `app.plugin.js` — the Expo config plugin now pins `kotlin-gradle-plugin:2.2.21` in the generated root `build.gradle` and injects the `META-INF/versions/9/OSGI-INF/MANIFEST.MF` packaging exclude into the generated app `build.gradle`, so Expo consumers need no changes
- `docs/get-started.md` / README — bare (non-Expo) RN apps pin the KGP version and add the packaging exclude themselves; documented with snippets
- `SQIPBuyerModule.kt` / `SQIPCardEntryModule.kt` / `SQIPGooglePayModule.kt` — `currentActivity` -> `getCurrentActivity()`; the Kotlin 2.2 compiler resolves the base-class getter as a plain function, not a synthetic property
- CHANGELOG updated

## Testing

`expo prebuild --clean` + `gradlew :app:assembleDebug` on `example-expo` with completely stock config — builds green with all IAP deps resolved at 1.6.9.

## Note for the SDK release itself

The Kotlin 2.3.0 metadata problem is not RN-specific: any integrator compiling with Kotlin < 2.2 hits the same error against IAP 1.6.9. Worth considering a respin compiled with a pinned `languageVersion`/`apiVersion`, which would remove the Kotlin requirement for all ecosystems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)