### PR TITLE
chore: release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## Changelog
 
-### v2.0.1 Jun 4, 2026
+### v2.1.0 Jul 23, 2026
 
-* Upgrade IAP SDK for Android `1.6.9` and for iOS `1.6.7`.
+* Upgrade IAP SDK for Android `1.6.9`.
 * IAP SDK Android `1.6.9` is built with Kotlin 2.3.0 and requires Kotlin `2.2.21`+ to compile, while React Native pins Kotlin 2.1.x (as of RN 0.86). The Expo config plugin now pins the Kotlin Gradle plugin to `2.2.21` automatically; bare React Native apps must pin it in their root `android/build.gradle` (see the [getting started guide](docs/get-started.md)).
 * IAP SDK Android `1.6.9` pulls in OkHttp 5.x, whose multi-release jars ship duplicate `META-INF/versions/9/OSGI-INF/MANIFEST.MF` entries and fail `mergeJavaResource`. The Expo config plugin now excludes it automatically; bare React Native apps should add a `packaging` exclude to `android/app/build.gradle` (see the [getting started guide](docs/get-started.md)).
+
+### v2.0.1 Jun 4, 2026
+
+* Upgrade IAP SDK for Android `1.6.8` and for iOS `1.6.7`.
 
 ### v1.7.6 Jun 03, 2024
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-square-in-app-payments",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "An open source React Native plugin for calling Square’s native In-App Payments SDK to take in-app payments on iOS and Android.",
   "main": "./lib/module/index.js",
   "types": "./lib/typescript/src/index.d.ts",


### PR DESCRIPTION
Release prep for v2.1.0: IAP SDK Android `1.6.9` + the Kotlin `2.2.21` build requirement from #264.

- `package.json` `2.0.1` -> `2.1.0` (minor, not patch — bare RN consumers gain a new build requirement: pin the Kotlin Gradle plugin to `2.2.21`)
- CHANGELOG: new `v2.1.0` section with the 1.6.9 / Kotlin / OkHttp notes. Also restores the `v2.0.1` entry to Android `1.6.8` — it had been edited in place by #264 under the assumption 2.0.1 was unreleased, but 2.0.1 shipped to npm on Jun 5 with Android 1.6.8, so the entry was misdescribing a published version.

After merge, publish by tagging (CI publishes to npm via the trusted-publisher workflow on tag push):

```
git checkout master && git pull
git tag v2.1.0 && git push origin v2.1.0
```

Linear: DEVMOB-1048

🤖 Generated with [Claude Code](https://claude.com/claude-code)