### PR TITLE
ci: bump publish workflow to Node 24

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -20,7 +20,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
           cache: 'yarn'
 


### PR DESCRIPTION
The [v2.1.0 publish run](https://github.com/square/in-app-payments-react-native-plugin/actions/runs/30047080423) failed at `npm install -g npm@latest`: latest npm is now 12, which requires Node 22+, while the workflow pins Node `20.x` (also EOL on GitHub runners — see the deprecation annotation on the run). The publish step never ran, so nothing was published.

After merging, the v2.1.0 tag needs to be moved to the fixed commit and re-pushed — workflow definitions are read from the tagged commit, so re-running the failed run would still use Node 20:

```
git checkout master && git pull
git push origin :refs/tags/v2.1.0
git tag -f v2.1.0 && git push origin v2.1.0
```

(Same recovery as v2.0.1, which was also tagged on its CI-fix commit.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)